### PR TITLE
Add MCTS rollouts

### DIFF
--- a/mcts.py
+++ b/mcts.py
@@ -28,9 +28,10 @@ def select(node, exploration_bonus):
     return node.outgoing_edges[index]
 
 
-def backprop(node, value):
+def backup(node, value):
     """
-    Propagate the value for the current node back
+    Propagate the value for the current node back up
+    the tree
     """
     cur_node = node
     # while not root, move the value up
@@ -84,7 +85,7 @@ def perform_rollouts(root_node,
         cur_node = edge.out_node
         # find a node you haven't expanded yet, expand it
         value = expand_node(cur_node, model, env)
-        backprop(cur_node, value)
+        backup(cur_node, value)
 
         n_leaf_expansions -= 1
 

--- a/mcts.py
+++ b/mcts.py
@@ -35,7 +35,7 @@ def backprop(node, value):
     cur_node = node
     # while not root, move the value up
     while cur_node.in_edge is not None:
-        edge = node.in_edge
+        edge = cur_node.in_edge
         edge.num_visits += 1
         edge.total_action_value += value
         cur_node = edge.in_node
@@ -77,11 +77,11 @@ def perform_rollouts(root_node,
     value = expand_node(root_node, model, env)
     while n_leaf_expansions > 0:
         # expand root
-        edge = select(cur_node, exploration_bonus)
-        cur_node = edge.out_node
-        while cur_node.num_visits != 0:
-            edge = select(cur_node, exploration_bonus)
+        edge = select(root_node, exploration_bonus)
+        while edge.num_visits != 0:
             cur_node = edge.out_node
+            edge = select(cur_node, exploration_bonus)
+        cur_node = edge.out_node
         # find a node you haven't expanded yet, expand it
         value = expand_node(cur_node, model, env)
         backprop(cur_node, value)

--- a/mcts.py
+++ b/mcts.py
@@ -1,48 +1,11 @@
 import numpy as np
+from functools import partial
+
+from model import LegalActionsOnlyModel
+from tree import Node, create_new_connection
 
 
-class Node(object):
-    def __init__(self, state, outgoing_edges=None, in_edge=None):
-        self.state = state
-        if outgoing_edges is not None:
-            self.outgoing_edges = outgoing_edges
-        else:
-            self.outgoing_edges = []
-        self.in_edge = in_edge
-
-    def add_outgoing_edge(self, edge):
-        self.outgoing_edges.append(edge)
-
-    def add_outgoing_edges(self, edges):
-        self.outgoing_edges.extend(edges)
-
-    def add_incoming_edge(self, edge):
-        self.in_edge = edge
-
-
-class Edge(object):
-    def __init__(self,
-                 in_node,
-                 out_node,
-                 action,
-                 prior_probability,
-                 num_visits=0,
-                 total_action_value=0.0):
-        self.in_node = in_node
-        self.out_node = out_node  # node
-        self.action = action
-        self.num_visits = num_visits
-        self.total_action_value = total_action_value
-        self.prior_probability = prior_probability
-
-    @property
-    def mean_action_value(self):
-        if self.num_visits == 0:
-            return 0.0
-        return self.total_action_value / self.num_visits
-
-
-def exploration_bonus(edge, c_puct):
+def exploration_bonus_for_c_puct(edge, c_puct):
     """
     Determines a score for an edge that favors exploration
     c_puct is a constant factor that scales how favorable exploration is
@@ -51,24 +14,18 @@ def exploration_bonus(edge, c_puct):
     return c_puct * edge.prior_probability * np.sqrt(sum_visits) / (1 + edge.num_visits)
 
 
-def select(node, c_puct):
+def select(node, exploration_bonus):
     """
     Select the next edge to expand
     c_puct is a constant factor that scales how favorable exploration is
+    exploration_bonus: function
+        Function that takes (edge) as input and returns a score based on
+        how good the edge is to explore with our exploration rate.
     """
-    def score(edge, c_puct):
-        return edge.mean_action_value + exploration_bonus(edge, c_puct)
-    index = np.argmax([score(edge, c_puct) for edge in node.outgoing_edges])
+    def score(edge):
+        return edge.mean_action_value + exploration_bonus(edge)
+    index = np.argmax([score(edge) for edge in node.outgoing_edges])
     return node.outgoing_edges[index]
-
-
-def evaluate(node, model, env):
-    """
-    Return the probability vector for actions,
-    and the value of the current state
-    """
-    prob_vector, value = model(node.state, env)
-    return prob_vector, value
 
 
 def backprop(node, value):
@@ -82,3 +39,90 @@ def backprop(node, value):
         edge.num_visits += 1
         edge.total_action_value += value
         cur_node = edge.in_node
+
+
+def expand_node(node, model, env):
+    action_probs, value = model(node)
+    for i, action_prob in enumerate(action_probs):
+        action = i  # actions are just indexes
+        next_state = env.get_next_state(node.state, action)
+        child_node = Node(next_state)
+        create_new_connection(node, child_node, action, action_prob)
+    return value
+
+
+def perform_rollouts(root_node,
+                     n_leaf_expansions,
+                     model,
+                     env,
+                     exploration_bonus):
+    """
+    Parameters
+    ----------
+    root_node: Node
+        initial node to start MCTS
+    n_leaf_expansions: int
+        number of leaves to expand in each iteration of MCTS when picking an action
+    model: function
+        Model to use for computing the value of each state,
+        prob_vector, value = model(node.state, env)
+    env:
+        game playing environment that can progress game state and give us legal moves
+    exploration_bonus: function
+        Function that takes (edge) as input and returns a score based on
+        how good the edge is to explore with our exploration rate.
+    """
+    cur_node = root_node
+    # add all edges and children for current node
+    value = expand_node(root_node, model, env)
+    while n_leaf_expansions > 0:
+        # expand root
+        edge = select(cur_node, exploration_bonus)
+        cur_node = edge.out_node
+        while cur_node.num_visits != 0:
+            edge = select(cur_node, exploration_bonus)
+            cur_node = edge.out_node
+        # find a node you haven't expanded yet, expand it
+        value = expand_node(cur_node, model, env)
+        backprop(cur_node, value)
+
+        n_leaf_expansions -= 1
+
+
+def get_action_distribution(start_state,
+                            temperature,
+                            n_leaf_expansions,
+                            model,
+                            env,
+                            c_puct):
+    """
+    Returns the distribution over all actions after exploring the trees.
+    This distribution pi(s) should be an improvement over the original p(s)
+    output by the model.
+
+    Parameters
+    ----------
+    root_node: Node
+        initial node to start MCTS
+    temperature: int
+        how much to explore low probability states
+    n_leaf_expansions: int
+        number of leaves to expand in each iteration of MCTS when picking an action
+    model: function
+        Model to use for computing the value of each state,
+        prob_vector, value = model(node.state, env)
+    env:
+        game playing environment that can progress game state and give us legal moves
+    c_puct: float
+        Constant that dictates how much score is assigned to exploring.
+    """
+    # set up the exploration_bonus function with the constant specified
+    exploration_bonus = partial(exploration_bonus_for_c_puct, c_puct=c_puct)
+
+    model = LegalActionsOnlyModel(model, env)
+    root_node = Node(start_state)
+    perform_rollouts(root_node, n_leaf_expansions, model, env, exploration_bonus)
+    visit_counts = np.array([edge.num_visits for edge in root_node.outgoing_edges])
+    distribution = np.power(visit_counts, 1/temperature)
+    # normalize
+    return distribution / np.sum(distribution)

--- a/model.py
+++ b/model.py
@@ -1,0 +1,29 @@
+import numpy as np
+
+
+class LegalActionsOnlyModel(object):
+    """
+    Wrapper for model that only outputs legal action probabilities
+    """
+    def __init__(self, model, env):
+        self.model = model
+        self.env = env
+
+    def __call__(self, state):
+        """
+        Return the probability vector for actions,
+        and the value of the current state
+
+        We assume the model will only output probabilities for legal actions
+        (TODO wrap actual model in suitable thing that filters)
+        """
+        action_probs, value = self.model(state)
+        legal_action_probs = []
+        for i, action_prob in enumerate(action_probs):
+            if self.env.is_legal(i):
+                legal_action_probs.append(action_prob)
+            else:
+                legal_action_probs.append(0.0)
+
+        legal_action_probs = np.array(legal_action_probs)
+        return legal_action_probs / np.sum(legal_action_probs), value

--- a/model.py
+++ b/model.py
@@ -20,7 +20,7 @@ class LegalActionsOnlyModel(object):
         action_probs, value = self.model(state)
         legal_action_probs = []
         for i, action_prob in enumerate(action_probs):
-            if self.env.is_legal(i):
+            if self.env.is_legal(state, i):
                 legal_action_probs.append(action_prob)
             else:
                 legal_action_probs.append(0.0)

--- a/tests/test_mcts.py
+++ b/tests/test_mcts.py
@@ -4,7 +4,7 @@ import unittest
 from mcts import backup, select, expand_node, exploration_bonus_for_c_puct, perform_rollouts, get_action_distribution
 from tree import Node
 
-from utils import setup_simple_tree, mock_model, mock_env
+from utils import setup_simple_tree, mock_model, mock_env, numline_env, mock_model_numline
 
 
 class TestMCTS(unittest.TestCase):
@@ -81,6 +81,22 @@ class TestRollouts(unittest.TestCase):
         edge0, edge1 = root_node.outgoing_edges
         self.assertEquals(edge0.num_visits, 1)
         self.assertEquals(edge1.num_visits, 1)
+
+    def test_numline_rollouts(self):
+        root_node = Node(0)
+        n_leaf_expansions = 100
+        c = 100  # to make sure we explore a new path every time
+        exploration_bonus = partial(exploration_bonus_for_c_puct, c_puct=c)
+        perform_rollouts(root_node, n_leaf_expansions, mock_model_numline, numline_env, exploration_bonus)
+        edge0, edge1 = root_node.outgoing_edges
+        edge10, edge11 = edge1.out_node.outgoing_edges
+        edge110, edge111 = edge11.out_node.outgoing_edges
+        edge1110, edge1111 = edge111.out_node.outgoing_edges
+        edge11110, edge11111 = edge1111.out_node.outgoing_edges
+
+        self.assertTrue(edge0.num_visits < edge1.num_visits)
+        self.assertTrue(edge10.num_visits < edge11.num_visits)
+        self.assertTrue(edge11110.num_visits > edge11111.num_visits)
 
     def test_get_action_distribution(self):
         start_state = 0

--- a/tests/test_mcts.py
+++ b/tests/test_mcts.py
@@ -1,0 +1,56 @@
+from functools import partial
+import unittest
+
+from mcts import backprop, select, expand_node, exploration_bonus_for_c_puct
+
+from utils import setup_simple_tree, mock_model, mock_env
+
+
+class TestMCTS(unittest.TestCase):
+    def setUp(self):
+        self.nodes = setup_simple_tree()
+
+    def test_backprop(self):
+        edge = self.nodes[1].in_edge
+        self.assertEqual(edge.action, 0)
+        self.assertEqual(edge.num_visits, 0)
+        self.assertEqual(edge.total_action_value, 0.0)
+        self.assertEqual(edge.mean_action_value, 0.0)
+
+        backprop(self.nodes[1], 1)
+
+        self.assertEqual(edge.action, 0)
+        self.assertEqual(edge.num_visits, 1)
+        self.assertEqual(edge.total_action_value, 1.0)
+        self.assertEqual(edge.mean_action_value, 1.0)
+
+    def test_select_exploration(self):
+        self.nodes[1].in_edge.num_visits = 100
+
+        # all things being equal, select unexplored action c=1
+        c = 1
+        exploration_bonus = partial(exploration_bonus_for_c_puct, c_puct=c)
+        selected_edge = select(self.nodes[0], exploration_bonus)
+
+        self.assertEqual(selected_edge.action, 1)
+        self.assertEqual(selected_edge.num_visits, 0)
+
+    def test_select_no_exploration(self):
+        self.nodes[1].in_edge.num_visits = 100
+        self.nodes[1].in_edge.total_action_value = 1000
+
+        # select the action with best known reward c=0
+        c = 0
+        exploration_bonus = partial(exploration_bonus_for_c_puct, c_puct=c)
+        selected_edge = select(self.nodes[0], exploration_bonus)
+
+        self.assertEqual(selected_edge.action, 0)
+        self.assertEqual(selected_edge.num_visits, 100)
+
+    def test_expand_node(self):
+        self.assertEqual(len(self.nodes[6].outgoing_edges), 0)
+        value = expand_node(self.nodes[6], mock_model, mock_env)
+        self.assertEqual(value, 1)
+        self.assertEqual(len(self.nodes[6].outgoing_edges), 2)
+        next_states = set(edge.out_node.state for edge in self.nodes[6].outgoing_edges)
+        self.assertEqual(next_states, {13, 14})

--- a/tests/test_mcts.py
+++ b/tests/test_mcts.py
@@ -94,6 +94,15 @@ class TestRollouts(unittest.TestCase):
         edge1110, edge1111 = edge111.out_node.outgoing_edges
         edge11110, edge11111 = edge1111.out_node.outgoing_edges
 
+        '''
+        This is a simple numberline environment with 2 discrete actions: left and right.  The start state is zero.
+        The agent gets reward of 10 at locations 2 and 3, reward of -10 from 4 onwards, and 0 on 1 and to the left
+        The environment (luckily) pushes actions that are likely to help it achieve its reward based on its state
+
+        The agent should explore the first action being to the right more than being to the left.  The same thing applies
+        for the second action since that's when it will really hit its reward.
+        But the 5th move should be to the left because it has gone off the cliff
+        '''
         self.assertTrue(edge0.num_visits < edge1.num_visits)
         self.assertTrue(edge10.num_visits < edge11.num_visits)
         self.assertTrue(edge11110.num_visits > edge11111.num_visits)

--- a/tests/test_mcts.py
+++ b/tests/test_mcts.py
@@ -1,7 +1,7 @@
 from functools import partial
 import unittest
 
-from mcts import backprop, select, expand_node, exploration_bonus_for_c_puct, perform_rollouts, get_action_distribution
+from mcts import backup, select, expand_node, exploration_bonus_for_c_puct, perform_rollouts, get_action_distribution
 from tree import Node
 
 from utils import setup_simple_tree, mock_model, mock_env
@@ -11,28 +11,28 @@ class TestMCTS(unittest.TestCase):
     def setUp(self):
         self.nodes = setup_simple_tree()
 
-    def test_backprop(self):
+    def test_backup(self):
         edge = self.nodes[1].in_edge
         self.assertEqual(edge.action, 0)
         self.assertEqual(edge.num_visits, 0)
         self.assertEqual(edge.total_action_value, 0.0)
         self.assertEqual(edge.mean_action_value, 0.0)
 
-        backprop(self.nodes[1], 1)
+        backup(self.nodes[1], 1)
 
         self.assertEqual(edge.action, 0)
         self.assertEqual(edge.num_visits, 1)
         self.assertEqual(edge.total_action_value, 1.0)
         self.assertEqual(edge.mean_action_value, 1.0)
 
-    def test_two_level_backprop(self):
+    def test_two_level_backup(self):
         edge = self.nodes[1].in_edge
         self.assertEqual(edge.action, 0)
         self.assertEqual(edge.num_visits, 0)
         self.assertEqual(edge.total_action_value, 0.0)
         self.assertEqual(edge.mean_action_value, 0.0)
 
-        backprop(self.nodes[4], 1)
+        backup(self.nodes[4], 1)
 
         self.assertEqual(edge.action, 0)
         self.assertEqual(edge.num_visits, 1)

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -1,10 +1,8 @@
 import unittest
 
-from mcts import Node, Edge, backprop, evaluate, select
+from tree import Node, Edge
 
-
-def mock_model(state, env):
-    return (0.5, 0.5), 1
+from utils import setup_simple_tree
 
 
 class TestInit(unittest.TestCase):
@@ -46,70 +44,3 @@ class TestInit(unittest.TestCase):
         # parent of 3 is 1
         self.assertEqual(nodes[3].in_edge.in_node.state, 1)
         self.assertEqual(len(nodes[6].outgoing_edges), 0)
-
-
-class TestMCTS(unittest.TestCase):
-    def setUp(self):
-        self.nodes = setup_simple_tree()
-
-    def test_backprop(self):
-        edge = self.nodes[1].in_edge
-        self.assertEqual(edge.action, 0)
-        self.assertEqual(edge.num_visits, 0)
-        self.assertEqual(edge.total_action_value, 0.0)
-        self.assertEqual(edge.mean_action_value, 0.0)
-
-        backprop(self.nodes[1], 1)
-
-        self.assertEqual(edge.action, 0)
-        self.assertEqual(edge.num_visits, 1)
-        self.assertEqual(edge.total_action_value, 1.0)
-        self.assertEqual(edge.mean_action_value, 1.0)
-
-    def test_select_exploration(self):
-        self.nodes[1].in_edge.num_visits = 100
-
-        # all things being equal, select unexplored action c=1
-        selected_edge = select(self.nodes[0], 1)
-
-        self.assertEqual(selected_edge.action, 1)
-        self.assertEqual(selected_edge.num_visits, 0)
-
-    def test_select_no_exploration(self):
-        self.nodes[1].in_edge.num_visits = 100
-        self.nodes[1].in_edge.total_action_value = 1000
-
-        # select the action with best known reward c=0
-        selected_edge = select(self.nodes[0], 0)
-
-        self.assertEqual(selected_edge.action, 0)
-        self.assertEqual(selected_edge.num_visits, 100)
-
-    def test_evaluate(self):
-        prob_vector, value = evaluate(self.nodes[0], mock_model, 'foo_env')
-        self.assertEqual(prob_vector, (0.5, 0.5))
-        self.assertEqual(value, 1)
-
-
-def setup_simple_tree():
-    #      0
-    #   1     2
-    #  3 4   5 6
-    nodes = [Node(i) for i in range(7)]
-    for i in range(3):
-        in_node = nodes[i]
-        out_node = nodes[2*(i + 1) - 1]
-        edge0 = Edge(in_node, out_node, 0, 0.5)
-        in_node.add_outgoing_edge(edge0)
-        out_node.add_incoming_edge(edge0)
-
-        out_node = nodes[2*(i + 1)]
-        edge1 = Edge(in_node, out_node, 1, 0.5)
-        in_node.add_outgoing_edge(edge1)
-        out_node.add_incoming_edge(edge1)
-
-    return nodes
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,41 @@
+from tree import Node, create_new_connection
+
+
+def mock_model(state):
+    return (0.5, 0.5), 1
+
+
+class MockEnv(object):
+    """
+    Functionality for the environment
+    """
+    def get_next_state(self, start_state, action):
+        """
+        Takes a state, action pair (indexes in the discrete case)
+        and returns the state that results from taking that action
+        """
+        return 2 * (start_state + 1) - 1 * action
+
+    def is_legal(self, state, action):
+        """
+        Given the current state and submitted action, is it legal?
+        """
+        return (action == 0 or action == 1)
+
+mock_env = MockEnv()
+
+
+def setup_simple_tree():
+    #      0
+    #   1     2
+    #  3 4   5 6
+    nodes = [Node(i) for i in range(7)]
+    for i in range(3):
+        in_node = nodes[i]
+        out_node = nodes[2*(i + 1) - 1]
+        create_new_connection(in_node, out_node, 0, 0.5)
+
+        out_node = nodes[2*(i + 1)]
+        create_new_connection(in_node, out_node, 1, 0.5)
+
+    return nodes

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -4,6 +4,18 @@ from tree import Node, create_new_connection
 def mock_model(state):
     return (0.5, 0.5), 1
 
+def mock_model_numline(node):
+    state = node.state
+    if state > 3:
+        value = -10
+        action_0_prob = 0.9
+    elif state > 1:
+        value = 10
+        action_0_prob = 0.5
+    else:
+        value = 0
+        action_0_prob = 0.1
+    return (action_0_prob, 1 - action_0_prob), state 
 
 class MockEnv(object):
     """
@@ -24,6 +36,24 @@ class MockEnv(object):
 
 mock_env = MockEnv()
 
+class MockEnv_numline(object):
+    """
+    Functionality for the environment
+    """
+    def get_next_state(self, start_state, action):
+        """
+        Takes a state, action pair (indexes in the discrete case)
+        and returns the state that results from taking that action
+        """
+        return start_state + (2*action - 1)
+
+    def is_legal(self, state, action):
+        """
+        Given the current state and submitted action, is it legal?
+        """
+        return (action == 0 or action == 1)
+
+numline_env = MockEnv_numline()
 
 def setup_simple_tree():
     #      0
@@ -38,4 +68,34 @@ def setup_simple_tree():
         out_node = nodes[2*(i + 1)]
         create_new_connection(in_node, out_node, 1, 0.5)
 
+    return nodes
+
+def setup_uneven_tree():
+    #        0
+    #    1        2
+    #  3    4  5     6
+    # 7 8              9
+    #10
+    #11
+    nodes = [Node(i) for i in range(12)]
+    for i in range(3):
+        action = 0
+        probability = 0.5
+        child_node = nodes[2*(i + 1) - 1]
+        nodes[i].add_edge_do_background_work(child_node, 0, probability)
+
+        action = 1
+        probability = 0.5
+        child_node = nodes[2*(i + 1)]
+        nodes[i].add_edge_do_background_work(child_node, 1, probability)
+
+    # 3->7 and 3->8
+    nodes[3].add_edge_do_background_work(nodes[7], 0, 0.2)
+    nodes[3].add_edge_do_background_work(nodes[8], 1, 0.8)
+
+    # # 6->9
+    nodes[6].add_edge_do_background_work(nodes[9], 0, 1.0)
+
+    # #7->10
+    nodes[7].add_edge_do_background_work(nodes[10], 1, 1.0)
     return nodes

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -99,3 +99,9 @@ def setup_uneven_tree():
     # #7->10
     nodes[7].add_edge_do_background_work(nodes[10], 1, 1.0)
     return nodes
+
+def map_xy_to_square(x, y):
+    return int(8*y + x)
+
+def map_square_to_xy(square):
+    return int(square % 8), int(square // 8)

--- a/tree.py
+++ b/tree.py
@@ -16,6 +16,9 @@ class Node(object):
     def add_incoming_edge(self, edge):
         self.in_edge = edge
 
+    def __repr__(self):
+        return 'Node. Children: {} State: {}'.format([edge.out_node.state for edge in self.outgoing_edges], self.state)
+
 
 class Edge(object):
     def __init__(self,
@@ -37,6 +40,9 @@ class Edge(object):
         if self.num_visits == 0:
             return 0.0
         return self.total_action_value / self.num_visits
+
+    def __repr__(self):
+        return 'Edge. In: {} Out: {} Action: {}'.format(self.in_node.state, self.out_node.state, self.action)
 
 
 def create_new_connection(parent_node, child_node, action, prior_probability):

--- a/tree.py
+++ b/tree.py
@@ -1,0 +1,49 @@
+class Node(object):
+    def __init__(self, state, outgoing_edges=None, in_edge=None):
+        self.state = state
+        if outgoing_edges is not None:
+            self.outgoing_edges = outgoing_edges
+        else:
+            self.outgoing_edges = []
+        self.in_edge = in_edge
+
+    def add_outgoing_edge(self, edge):
+        self.outgoing_edges.append(edge)
+
+    def add_outgoing_edges(self, edges):
+        self.outgoing_edges.extend(edges)
+
+    def add_incoming_edge(self, edge):
+        self.in_edge = edge
+
+
+class Edge(object):
+    def __init__(self,
+                 in_node,
+                 out_node,
+                 action,
+                 prior_probability,
+                 num_visits=0,
+                 total_action_value=0.0):
+        self.in_node = in_node
+        self.out_node = out_node  # node
+        self.action = action
+        self.num_visits = num_visits
+        self.total_action_value = total_action_value
+        self.prior_probability = prior_probability
+
+    @property
+    def mean_action_value(self):
+        if self.num_visits == 0:
+            return 0.0
+        return self.total_action_value / self.num_visits
+
+
+def create_new_connection(parent_node, child_node, action, prior_probability):
+    """
+    Returns the edge connecting root and child
+    """
+    edge = Edge(parent_node, child_node, action, prior_probability)
+    parent_node.add_outgoing_edge(edge)
+    child_node.add_incoming_edge(edge)
+    return edge

--- a/tree.py
+++ b/tree.py
@@ -41,7 +41,7 @@ class Edge(object):
 
 def create_new_connection(parent_node, child_node, action, prior_probability):
     """
-    Returns the edge connecting root and child
+    Returns the edge connecting parent and child
     """
     edge = Edge(parent_node, child_node, action, prior_probability)
     parent_node.add_outgoing_edge(edge)


### PR DESCRIPTION
This PR adds the functionality for recovering a better policy action distribution \pi from an existing model's output p.

I've also done a bit of housekeeping, sorry if it's confusing in the PR.

I factored things out into 

tree.py (node and edge class. Unchanged from the previous PR)
model.py (a wrapper class that ensures actions submitted to the environment are legal)
mcts.py (exploring the state tree and backprop-ing values. Some additions from previous PR)

Within /tests, there's
util.py (shared functionality between tests. Unchanged from previous PR)
test_tree.py (Unchanged from previous PR)
test_mcts.py (Added tests for the select, expand/evaluate, backup)

![image](https://user-images.githubusercontent.com/10425351/32402421-1ddecfd0-c0e1-11e7-890e-a43626a0b339.png)

A few tests of speed... I think the number of leaves we expand on each iteration of MCTS could definitely be a bottleneck in our overall runtime. 

```
In [6]: %timeit distribution = get_action_distribution(start_state, temperature, 1, mock_model, mock_env, c)
78.4 µs ± 1.47 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)

In [7]: %timeit distribution = get_action_distribution(start_state, temperature, 10, mock_model, mock_env, c)
833 µs ± 10.7 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

In [8]: %timeit distribution = get_action_distribution(start_state, temperature, 100, mock_model, mock_env, c)
15.5 ms ± 351 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

In [9]: %timeit distribution = get_action_distribution(start_state, temperature, 1000, mock_model, mock_env, c)
277 ms ± 32.3 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```