### PR TITLE
Speed up model prediction tests by not setting up both nets every time

### DIFF
--- a/tests/test_net.py
+++ b/tests/test_net.py
@@ -7,30 +7,35 @@ from dual_net import DualNet
 
 class TestPrediction(unittest.TestCase):
     def setUp(self):
-        self.sess = tf.Session()
-        self.net = DualNet(self.sess)
-        self.piece_net = DualNet(self.sess, representation='piece')
-
-        self.sess.__enter__()
-        tf.global_variables_initializer().run()
-
         self.boards = np.random.random_sample([10, 8, 8, 13])
         self.z = np.random.random_sample([10])
 
     def test_predict(self):
-        policy, value = self.net(self.boards)
+        sess = tf.Session()
+        net = DualNet(sess)
+        sess.__enter__()
+        tf.global_variables_initializer().run()
+        policy, value = net(self.boards)
         self.assertEqual(policy.shape, (10, 64*64))
 
     def test_predict_with_piece_action(self):
-        policy, value = self.piece_net(self.boards)
+        sess = tf.Session()
+        piece_net = DualNet(sess, representation='piece')
+        sess.__enter__()
+        tf.global_variables_initializer().run()
+        policy, value = piece_net(self.boards)
         self.assertEqual(policy.shape, (10, 32*64))
 
     def test_regularization(self):
+        sess = tf.Session()
+        net = DualNet(sess)
+        sess.__enter__()
+        tf.global_variables_initializer().run()
         pi = np.random.random_sample([10, 64*64])
-        regularization_loss = self.sess.run(self.net.regularization_loss,
-                                            feed_dict={self.net.board_placeholder: self.boards,
-                                                       self.net.pi: pi,
-                                                       self.net.z: self.z})
+        regularization_loss = sess.run(net.regularization_loss,
+                                       feed_dict={net.board_placeholder: self.boards,
+                                                  net.pi: pi,
+                                                  net.z: self.z})
         self.assertGreater(regularization_loss, 0)
 
 if __name__ == '__main__':


### PR DESCRIPTION
Before 48.94 seconds 
```
(venv) nthomas (master) castle $ PYTHONPATH=. py.test
============================================================================================================ test session starts ============================================================================================================
platform darwin -- Python 3.6.2, pytest-3.2.3, py-1.4.34, pluggy-0.4.0
rootdir: /Users/nthomas/git/castle, inifile:
plugins: cov-2.5.1
collected 11 items

tests/test_net.py ...
tests/test_tree.py ........

======================================================================================================== 11 passed in 48.94 seconds =========================================================================================================
```

After 14.45 seconds
```
(venv) nthomas (master *) castle $ PYTHONPATH=. py.test
============================================================================================================ test session starts ============================================================================================================
platform darwin -- Python 3.6.2, pytest-3.2.3, py-1.4.34, pluggy-0.4.0
rootdir: /Users/nthomas/git/castle, inifile:
plugins: cov-2.5.1
collected 11 items

tests/test_net.py ...
tests/test_tree.py ........

======================================================================================================== 11 passed in 14.45 seconds =========================================================================================================

```