### PR TITLE
Fix action index conversion

### DIFF
--- a/chess_env.py
+++ b/chess_env.py
@@ -110,7 +110,7 @@ class ChessEnv(object):
                     continue
                 state[i][j][CHAR_TO_INDEX_MAP[char]] = 1
         if board.turn:
-            state[:,:,12] = np.ones(shape=(8,8))
+            state[:, :, 12] = np.ones(shape=(8, 8))
         return state
 
     def map_state_to_board(self, state):
@@ -169,8 +169,7 @@ class ChessEnv(object):
         if self.action_size == POSITION_POSITION_ACTION_SIZE:
             return 64 * from_pos + to_pos
         elif self.action_size == PIECE_POSITION_ACTION_SIZE:
-            # not implemented
-            pass
+            raise NotImplementedError
 
     def position_to_index(self, position):
         """

--- a/kqk_chess_env.py
+++ b/kqk_chess_env.py
@@ -52,7 +52,7 @@ class KQKChessEnv(object):
         self.action_regime = action_regime
         if action_regime == 'KQK_pos_pos_piece':
             self.action_dims = (8, 8, 8, 8, 3)
-            #TensorFlow doesn't like being passed np.int64, so cast as int
+            # TensorFlow doesn't like being passed np.int64, so cast as int
             self.action_size = int(np.prod(self.action_dims))
         elif action_regime == 'KQK_pos_pos':
             self.action_dims = (8, 8, 8, 8)
@@ -68,12 +68,11 @@ class KQKChessEnv(object):
 
     def get_legal_actions(self, state):
         board = self.map_state_to_board(state)
-        legal_moves = board.legal_moves
-        legal_actions = np.zeros(len(legal_moves), dtype=int)
+        legal_actions = []
         i = 0
-        for move in legal_moves:
+        for move in board.legal_moves:
             action = self.map_move_to_action(board, move)
-            legal_actions[i] = action
+            legal_actions.append(action)
             i += 1
         return legal_actions
 
@@ -110,7 +109,7 @@ class KQKChessEnv(object):
 
     def convert_action_to_int(self, action_array):
         action_array = np.reshape(action_array, -1)
-        return np.where(action_array == 1)[0]
+        return np.argmax(action_array)
 
     def convert_int_to_action(self, action_int):
         action_array = np.zeros((self.action_dims), dtype=int)

--- a/mcts.py
+++ b/mcts.py
@@ -54,8 +54,7 @@ def expand_node(node, model, env):
     action_probs = vec_action_probs[0]
     value = values[0]
     legal_actions = env.get_legal_actions(node.state)
-    for i in range(legal_actions.size):
-        action = legal_actions[i]
+    for i, action in enumerate(legal_actions):
         action_prob = action_probs[i]
         next_state = env.get_next_state(node.state, action)
         child_node = Node(next_state)

--- a/tests/test_chess_env.py
+++ b/tests/test_chess_env.py
@@ -1,9 +1,17 @@
 import unittest
 
-import numpy as np
 import chess
 
 from chess_env import ChessEnv
+
+INITIAL_BLACK_PAWNS_STRING = ('[[ 0.  0.  0.  0.  0.  0.  0.  0.]\n'
+                              ' [ 1.  1.  1.  1.  1.  1.  1.  1.]\n'
+                              ' [ 0.  0.  0.  0.  0.  0.  0.  0.]\n'
+                              ' [ 0.  0.  0.  0.  0.  0.  0.  0.]\n'
+                              ' [ 0.  0.  0.  0.  0.  0.  0.  0.]\n'
+                              ' [ 0.  0.  0.  0.  0.  0.  0.  0.]\n'
+                              ' [ 0.  0.  0.  0.  0.  0.  0.  0.]\n'
+                              ' [ 0.  0.  0.  0.  0.  0.  0.  0.]]')
 
 
 class TestChessEnv(unittest.TestCase):
@@ -23,7 +31,7 @@ class TestChessEnv(unittest.TestCase):
         board = chess.Board()
         state = self.env.map_board_to_state(board)
         # Checks top two rows of the black pawn layer
-        self.assertEqual(str(state[0:2,:,11]), '[[ 0.  0.  0.  0.  0.  0.  0.  0.]\n [ 1.  1.  1.  1.  1.  1.  1.  1.]]')
+        self.assertEqual(str(state[:, :, 11]), INITIAL_BLACK_PAWNS_STRING)
 
     def test_state_to_board(self):
         board = chess.Board()

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -3,11 +3,9 @@ import unittest
 import numpy as np
 import tensorflow as tf
 
-from chess_env import ChessEnv
-from kqk_chess_env import KQKChessEnv
 from dual_net import DualNet
-from kqk_chess_env import KQK_CHESS_INPUT_SHAPE, KQK_POSITION_POSITION_PIECE_ACTION_SIZE
 from game import self_play_game
+from kqk_chess_env import KQKChessEnv, KQK_CHESS_INPUT_SHAPE
 
 from utils import numline_env, mock_model_numline
 

--- a/tests/test_kqk_chess_env.py
+++ b/tests/test_kqk_chess_env.py
@@ -15,7 +15,7 @@ class TestKQKChessEnv(unittest.TestCase):
         start_state[2, 0, 1] = 1
         start_state[0, 0, 2] = 1
         start_state[:, :, 3] = np.zeros((8, 8))
-        self.assertEqual(self.env.get_legal_actions(start_state).size, 0)
+        self.assertEqual(len(self.env.get_legal_actions(start_state)), 0)
         self.assertTrue(self.env.is_game_over(start_state))
         self.assertEqual(self.env.outcome(start_state), 1)
 
@@ -25,7 +25,7 @@ class TestKQKChessEnv(unittest.TestCase):
         start_state[2, 0, 1] = 1
         start_state[3, 3, 2] = 1
         start_state[:, :, 3] = np.ones((8, 8))
-        num_legal_moves = self.env.get_legal_actions(start_state).size
+        num_legal_moves = len(self.env.get_legal_actions(start_state))
         self.assertTrue(num_legal_moves > 0)
         self.assertFalse(self.env.is_game_over(start_state))
 
@@ -55,4 +55,12 @@ class TestKQKChessEnv(unittest.TestCase):
         start_state[0, 2, 0] = 1
         start_state[5, 5, 1] = 1
         start_state[0, 0, 2] = 1
-        self.assertEqual(self.env.get_legal_actions(start_state).size, 1)
+        self.assertEqual(len(self.env.get_legal_actions(start_state)), 1)
+
+    def test_convert_action_to_int(self):
+        action = np.zeros((8, 8, 8, 8, 3), dtype=int)
+        action[3, 3, 4, 4, 2] = 1
+        action_int = self.env.convert_action_to_int(action)
+        recovered_action = self.env.convert_int_to_action(action_int)
+        self.assertEqual(type(action_int), np.int64)
+        self.assertEqual(action[3, 3, 4, 4, 2], recovered_action[3, 3, 4, 4, 2])

--- a/tests/test_tictactoe_env.py
+++ b/tests/test_tictactoe_env.py
@@ -11,7 +11,7 @@ class TestTicTacToeEnv(unittest.TestCase):
 
     def test_init(self):
         start_state = np.zeros((2, 3, 3), dtype=int)
-        self.assertEqual(self.env.get_legal_actions(start_state).size, 9)
+        self.assertEqual(len(self.env.get_legal_actions(start_state)), 9)
 
     def test_1_move(self):
         start_state = np.zeros((2, 3, 3), dtype=int)
@@ -25,7 +25,7 @@ class TestTicTacToeEnv(unittest.TestCase):
         true_next_state[0, 1, 1] = 1
 
         self.assertTrue(np.array_equal(true_next_state, next_state))
-        self.assertEqual(self.env.get_legal_actions(next_state).size, 8)
+        self.assertEqual(len(self.env.get_legal_actions(next_state)), 8)
 
     def test_2_moves(self):
         start_state = np.zeros((2, 3, 3), dtype=int)
@@ -38,7 +38,7 @@ class TestTicTacToeEnv(unittest.TestCase):
         action_array = np.zeros((2, 3, 3), dtype=int)
         action_array[1, 1, 0] = 1
         action_int = self.env.convert_action_to_int(action_array)
-        self.assertEqual(self.env.get_legal_actions(next_state).size, 8)
+        self.assertEqual(len(self.env.get_legal_actions(next_state)), 8)
         next_state = self.env.get_next_state(next_state, action_int)
 
         true_next_state = np.zeros((2, 3, 3), dtype=int)
@@ -46,7 +46,7 @@ class TestTicTacToeEnv(unittest.TestCase):
         true_next_state[1, 1, 0] = 1
 
         self.assertTrue(np.array_equal(true_next_state, next_state))
-        self.assertEqual(self.env.get_legal_actions(next_state).size, 7)
+        self.assertEqual(len(self.env.get_legal_actions(next_state)), 7)
 
     def test_x_win(self):
         start_state = np.zeros((2, 3, 3), dtype=int)
@@ -151,3 +151,11 @@ class TestTicTacToeEnv(unittest.TestCase):
         invalid_state[1, 0, 1] = 1
         with self.assertRaises(InvalidStateException):
             self.env.is_x_turn(invalid_state)
+
+    def test_convert_action_to_int(self):
+        action = np.zeros((2, 3, 3), dtype=int)
+        action[1, 0, 2] = 1
+        action_int = self.env.convert_action_to_int(action)
+        recovered_action = self.env.convert_int_to_action(action_int)
+        self.assertEqual(type(action_int), np.int64)
+        self.assertEqual(action[1, 0, 2], recovered_action[1, 0, 2])

--- a/tictactoe_env.py
+++ b/tictactoe_env.py
@@ -86,12 +86,17 @@ class TicTacToeEnv(object):
 
     def convert_action_to_int(self, action_array):
         """
-        action_array is 2x3x3
+        Return an integer representing the index of the chosen action
+        in the dimension of space 2x3x3.
         """
         action_array = np.reshape(action_array, -1)
-        return np.where(action_array == 1)[0]
+        return np.argmax(action_array)
 
     def convert_int_to_action(self, action_int):
+        """
+        Conver the action index (an integer) into the
+        array representation of the action
+        """
         action_array = np.zeros((self.action_dims), dtype=int)
         action_array = np.reshape(action_array, -1)
         action_array[action_int] = 1

--- a/tictactoe_env.py
+++ b/tictactoe_env.py
@@ -94,7 +94,7 @@ class TicTacToeEnv(object):
 
     def convert_int_to_action(self, action_int):
         """
-        Conver the action index (an integer) into the
+        Convert the action index (an integer) into the
         array representation of the action
         """
         action_array = np.zeros((self.action_dims), dtype=int)


### PR DESCRIPTION
The meat of this PR is basically

```
-        return np.where(action_array == 1)[0]
+        return np.argmax(action_array)
```

This is enshrined in a test added for the KQK and tictactoe env. (Maybe ChessEnv needs it too?)

The changes in the rest of the files are just formatting/unused import cleanup.